### PR TITLE
startup.cs was incorrect because it was always calling the 'not devel…

### DIFF
--- a/OutcomesFirst/Startup.cs
+++ b/OutcomesFirst/Startup.cs
@@ -59,10 +59,10 @@ namespace OutcomesFirst
         {
             if (env.IsDevelopment())
             {
-                //app.UseDeveloperExceptionPage();
-                //app.UseDatabaseErrorPage();
+                app.UseDeveloperExceptionPage();
+                app.UseDatabaseErrorPage();
 
-                app.UseExceptionHandler("/Home/Error");
+                //app.UseExceptionHandler("/Home/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
 


### PR DESCRIPTION
…opment' error page.